### PR TITLE
Swap to singleton function

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,11 +45,11 @@ export class SelfDestruct extends Construct {
       },
     });
 
-    const selfDestructLambda = new lambda.Function(
+    const selfDestructLambda = new lambda.SingletonFunction(
       this,
       "self-destruct-stack-app",
       {
-        functionName: "self-destruct-function",
+        uuid: "6024fd94-c050-11ea-b3de-0242ac130004",
         runtime: lambda.Runtime.PYTHON_3_6,
         role: selfDestructRole,
         handler: "index.handler",
@@ -66,7 +66,6 @@ def handler(event, context):
       }
     );
 
-    //Every 10 minutes
     const rule = new Rule(this, "SelfDestructRule", {
       schedule: Schedule.rate(props.timeToLive),
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "time-bomb",
+  "name": "cdk-time-bomb",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Thanks for the awesome construct, this little PR addresses two issues when I encountered when I tried to use it in a multi-stack app:

1) Removes the hardcoded function name, allowing CDK to control the name (this is best practice).

2) Using a SingletonFunction so apps with multiple stacks don't need to deploy multiple copies of the same lambda.

Finally, would you consider matching your release versions to match the CDK dependency version? This makes it easier for users to install the correct version of this lib to match their underlying CDK version. We use this to great effect [here](https://github.com/mobileposse/auto-delete-bucket/tags).