### PR TITLE
fix: reduce self-destruct lambda iam permissions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,13 +19,18 @@ export class SelfDestruct extends Construct {
 
     const selfDestructPolicy: PolicyDocument = new PolicyDocument();
 
+    const stack = cdk.Stack.of(this);
+
     /** define inline policies */
     const selfDestructPolicyStatements: PolicyStatement[] = [
-      //temporarily allow ALL
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ["*"],
-        resources: ["*"],
+        actions: ["cloudformation:DeleteStack"],
+        resources: [stack.formatArn({
+          service: 'cloudformation',
+          resource: 'stack',
+          resourceName: stack.stackName+'/*',
+        })],
       }),
     ];
 


### PR DESCRIPTION
The lambda function should only have permission to delete its own stack - not full permission to everything in the AWS account.

Great idea for a CDK construct though - I love it 😄 